### PR TITLE
(exa PR) 1049: Adds "almost all" flag (-A) for compatibility with zsh's la alias

### DIFF
--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -160,10 +160,7 @@ impl DotFilter {
         if count == 0 && almost_count == 0 {
             Ok(Self::JustFiles)
         }
-        else if almost_count == 1 {
-            Ok(Self::Dotfiles)
-        }
-        else if count == 1 {
+        else if count == 1 || almost_count == 1 {
             Ok(Self::Dotfiles)
         }
         else if matches.count(&flags::TREE) > 0 {

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -155,9 +155,13 @@ impl DotFilter {
     /// parent directory in tree mode would loop onto itself!
     pub fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
         let count = matches.count(&flags::ALL);
+        let almost_count = matches.count(&flags::ALMOST_ALL);
 
-        if count == 0 {
+        if count == 0 && almost_count == 0 {
             Ok(Self::JustFiles)
+        }
+        else if almost_count == 1 {
+            Ok(Self::Dotfiles)
         }
         else if count == 1 {
             Ok(Self::Dotfiles)

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -23,6 +23,7 @@ pub static COLOUR_SCALE: Arg = Arg { short: None, long: "colour-scale", takes_va
 
 // filtering and sorting options
 pub static ALL:         Arg = Arg { short: Some(b'a'), long: "all",         takes_value: TakesValue::Forbidden };
+pub static ALMOST_ALL:         Arg = Arg { short: Some(b'A'), long: "allmost-all",         takes_value: TakesValue::Forbidden };
 pub static LIST_DIRS:   Arg = Arg { short: Some(b'd'), long: "list-dirs",   takes_value: TakesValue::Forbidden };
 pub static LEVEL:       Arg = Arg { short: Some(b'L'), long: "level",       takes_value: TakesValue::Necessary(None) };
 pub static REVERSE:     Arg = Arg { short: Some(b'r'), long: "reverse",     takes_value: TakesValue::Forbidden };
@@ -73,7 +74,7 @@ pub static ALL_ARGS: Args = Args(&[
     &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY,
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE,
 
-    &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
+    &ALL, &ALMOST_ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS,
 
     &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,


### PR DESCRIPTION
https://github.com/ogham/exa/pull/1049