### PR TITLE
fix(color-scale): use file size unit custom color when not using color scale

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -109,7 +109,7 @@ Use comma(,) separated list of all, age, size
 `--color-scale-mode=MODE`, `--colour-scale-mode=MODE`
 : Use gradient or fixed colors in `--color-scale`.
 
-Valid options are `fixed` or `gradient`.
+Valid options are `fixed` to use a fixed color (disabling color scale), or `gradient` to use an automatic darker (old/small file) to lighter (recent/big file) gradient of colors.
 When used without a value, defaults to `gradient`.
 
 `--icons=WHEN`

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -34,7 +34,9 @@ impl Default for ColorScaleOptions {
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum ColorScaleMode {
+    // Color scale is disabled, use a static color for the range
     Fixed,
+    // Color scale uses an automatic gradient of colors for the range
     Gradient,
 }
 

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -89,7 +89,7 @@ impl f::Size {
                 vec![
                     csi.adjust_style(colours.size(Some(prefix)), size as f32, csi.size)
                         .paint(number),
-                    csi.adjust_style(colours.size(Some(prefix)), size as f32, csi.size)
+                    csi.adjust_style(colours.unit(Some(prefix)), size as f32, csi.size)
                         .paint(symbol),
                 ]
             } else {

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -147,7 +147,7 @@ impl Default for UiStyles {
 
 impl Size {
     pub fn colourful(scale: ColorScaleOptions) -> Self {
-        if scale.size && scale.mode == ColorScaleMode::Fixed {
+        if scale.mode == ColorScaleMode::Fixed {
             Self::colourful_fixed()
         } else {
             Self::colourful_gradient()


### PR DESCRIPTION
Fixes #682 

After half a year I finally went down the rabbit hole and fixed this bug I reported 🙃

I tested different combination of options and the program seems to work correctly in all cases.

Let me know what you think, are there existing tests for this specific part of the renderer?

---
See how the file size unit is always using [my custom colors](https://github.com/eza-community/eza/issues/315#issuecomment-1732554735) when color scale is not applied on the file size:
![image](https://github.com/eza-community/eza/assets/9730330/f653ae17-8eff-4eec-b9a9-34fc88a8e789)

![image](https://github.com/eza-community/eza/assets/9730330/f51a56ad-909d-4bef-a879-c42c2f2e9b19)

![image](https://github.com/eza-community/eza/assets/9730330/0fc35996-6cee-466b-8a08-233fe36596f5)

And when using color scale for the file size:
![image](https://github.com/eza-community/eza/assets/9730330/0363a272-5260-4f73-8cb1-22aa9a6f6293)
