### PR TITLE
fix: colour file kind indicators

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -291,7 +291,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
 
                         if should_add_classify_char {
                             if let Some(class) = self.classify_char(target) {
-                                bits.push(Style::default().paint(class));
+                                bits.push(self.colours.classify_char().paint(class));
                             }
                         }
                     }
@@ -317,7 +317,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
             }
         } else if should_add_classify_char {
             if let Some(class) = self.classify_char(self.file) {
-                bits.push(Style::default().paint(class));
+                bits.push(self.colours.classify_char().paint(class));
             }
         }
 
@@ -540,6 +540,9 @@ pub trait Colours: FiletypeColours {
 
     /// The style to paint a directory that has a filesystem mounted on it.
     fn mount_point(&self) -> Style;
+
+    /// The style to paint a file kind indicator.
+    fn classify_char(&self) -> Style;
 
     fn colour_file(&self, file: &File<'_>) -> Style;
 

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -412,6 +412,7 @@ impl FileNameColours for Theme {
     fn broken_control_char(&self) -> Style { apply_overlay(self.ui.control_char(),   self.ui.broken_path_overlay()) }
     fn executable_file(&self)     -> Style { self.ui.filekinds.unwrap_or_default().executable() }
     fn mount_point(&self)         -> Style { self.ui.filekinds.unwrap_or_default().mount_point() }
+    fn classify_char(&self)       -> Style { self.ui.punctuation() }
 
     fn colour_file(&self, file: &File<'_>) -> Style {
         self.exts


### PR DESCRIPTION
Uses the punctuation style.

Tested using `nix run . -- -F` and `nix run . -- -lF`.

Wasn't sure if I should use "fix" or "feat" in the commit message. Hope this is okay.