### PR TITLE
feat(windows): report executable files

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -25,7 +25,6 @@ use std::time::SystemTime;
 use chrono::prelude::*;
 
 use log::{debug, error, trace};
-#[cfg(unix)]
 use std::sync::LazyLock;
 
 use crate::fs::dir::Dir;
@@ -351,6 +350,34 @@ impl<'dir> File<'dir> {
             return false;
         };
         (md.permissions().mode() & bit) == bit
+    }
+
+    #[cfg(windows)]
+    pub fn is_executable_file(&self) -> bool {
+        use std::collections::HashSet;
+        use std::env;
+
+        let Some(ext) = self.ext.as_ref() else {
+            return false;
+        };
+
+        if !self.is_file() {
+            return false;
+        }
+
+        static PATHEXT: LazyLock<HashSet<String>> = LazyLock::new(|| {
+            env::var("PATHEXT")
+                .unwrap_or_default()
+                .split(';')
+                .filter_map(|s| {
+                    if !s.starts_with('.') {
+                        return None;
+                    }
+                    s[1..].to_ascii_uppercase().into()
+                })
+                .collect::<HashSet<String>>()
+        });
+        PATHEXT.contains(&ext.to_ascii_uppercase())
     }
 
     /// Whether this file is a symlink on the filesystem.

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -485,7 +485,6 @@ impl<C: Colours> FileName<'_, '_, C> {
         return match self.file {
             f if f.is_mount_point()      => self.colours.mount_point(),
             f if f.is_directory()        => self.colours.directory(),
-            #[cfg(unix)]
             f if f.is_executable_file()  => self.colours.executable_file(),
             f if f.is_link()             => self.colours.symlink(),
             #[cfg(unix)]


### PR DESCRIPTION
[`$PATHEXT`](https://www.nextofwindows.com/what-is-pathext-environment-variable-in-windows) is an Environment Variable that stores a list of the file extensions for operation system to execute. A file is considered executable if its extension matches `$PATHEXT`

```dos
C:\>echo %PATHEXT%
.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
```