### PR TITLE
fix: support additional yaml file extension

### DIFF
--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -628,43 +628,43 @@ mod tests {
 
     #[test]
     fn parse_none_color_from_string() {
-        ["", "none", "None"].iter().for_each(|case| {
+        for case in &["", "none", "None"] {
             assert_eq!(color_from_str(case), None);
-        });
+        }
     }
 
     #[test]
     fn parse_default_color_from_string() {
-        ["default", "Default"].iter().for_each(|case| {
+        for case in &["default", "Default"] {
             assert_eq!(color_from_str(case), Some(Color::Default));
-        });
+        }
     }
 
     #[test]
     fn parse_fixed_color_from_string() {
-        ["black", "Black"].iter().for_each(|case| {
+        for case in &["black", "Black"] {
             assert_eq!(color_from_str(case), Some(Color::Black));
-        });
+        }
     }
 
     #[test]
     fn parse_long_hex_color_from_string() {
-        ["#ff00ff", "#FF00FF"].iter().for_each(|case| {
+        for case in &["#ff00ff", "#FF00FF"] {
             assert_eq!(color_from_str(case), Some(Color::Rgb(255, 0, 255)));
-        });
+        }
     }
 
     #[test]
     fn parse_short_hex_color_from_string() {
-        ["#f0f", "#F0F"].iter().for_each(|case| {
+        for case in ["#f0f", "#F0F"].iter() {
             assert_eq!(color_from_str(case), Some(Color::Rgb(255, 0, 255)));
-        });
+        }
     }
 
     #[test]
     fn parse_color_code_from_string() {
-        [("10", 10), ("01", 1)].iter().for_each(|(s, c)| {
+        for (s, c) in &[("10", 10), ("01", 1)] {
             assert_eq!(color_from_str(s), Some(Color::Fixed(*c)));
-        });
+        }
     }
 }

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -35,23 +35,26 @@ impl Options {
 
 impl ThemeConfig {
     fn deduce<V: Vars>(vars: &V) -> Option<Self> {
-        if let Some(path) = vars.get("EZA_CONFIG_DIR") {
-            let path = PathBuf::from(path);
-            let path = path.join("theme.yml");
-            if path.exists() {
-                Some(ThemeConfig::from_path(&path.to_string_lossy()))
-            } else {
-                None
-            }
+        let (base_path, is_default_location) = if let Some(path) = vars.get("EZA_CONFIG_DIR") {
+            (PathBuf::from(path), false)
+        } else if let Some(path) = dirs::config_dir() {
+            (path.join("eza"), true)
         } else {
-            let path = dirs::config_dir().unwrap_or_default();
-            let path = path.join("eza").join("theme.yml");
-            if path.exists() {
-                Some(ThemeConfig::default())
+            return None;
+        };
+        let yml_path = base_path.join("theme.yml");
+        if yml_path.exists() {
+            return if is_default_location {
+                Some(ThemeConfig::from_path(&yml_path.to_string_lossy()))
             } else {
-                None
-            }
+                Some(ThemeConfig::default())
+            };
         }
+        let yaml_path = base_path.join("theme.yaml");
+        if yaml_path.exists() {
+            return Some(ThemeConfig::from_path(&yaml_path.to_string_lossy()));
+        }
+        None
     }
 }
 


### PR DESCRIPTION
#1324 

probably mostly thanks to kubernetes ;), the `.yaml` file extension is often used interchangeably with `.yml`, we should probably support this.

also added clippy recommendations from `config.rs`