### PR TITLE
fix: ignore extensions for directories when sorting

### DIFF
--- a/devtools/dir-generator.sh
+++ b/devtools/dir-generator.sh
@@ -133,6 +133,17 @@ touch icons/man.1 --date=@0
 touch icons/marked.md --date=@0
 # END test_icons
 
+# BEGIN test_dirs-ext
+mkdir -p dirs-ext
+mkdir dirs-ext/test
+mkdir dirs-ext/abc
+mkdir dirs-ext/01.city
+mkdir dirs-ext/02.apple
+touch dirs-ext/a.txt --date=@0
+touch dirs-ext/abc.mp3 --date=@0
+touch dirs-ext/ab --date=@0
+# END test_dirs_ext
+
 # BEGIN set date
 touch --date=@0 ./*;
 # END set date

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -288,14 +288,15 @@ impl SortField {
                 order            => order,
             },
 
-            Self::Extension(ABCabc) => match a.ext.cmp(&b.ext) {
-                Ordering::Equal  => natord::compare(&a.name, &b.name),
-                order            => order,
-            },
-
-            Self::Extension(AaBbCc) => match a.ext.cmp(&b.ext) {
-                Ordering::Equal  => natord::compare_ignore_case(&a.name, &b.name),
-                order            => order,
+            Self::Extension(case) => {
+                // Ignore extensions for directories when sorting.
+                let left = if a.is_directory() { &None } else { &a.ext };
+                let right = if b.is_directory() { &None } else { &b.ext };
+                match (left.cmp(right), case) {
+                    (Ordering::Equal, ABCabc)  => natord::compare(&a.name, &b.name),
+                    (Ordering::Equal, AaBbCc)  => natord::compare_ignore_case(&a.name, &b.name),
+                    (order, _)                 => order,
+                }
             },
 
             Self::NameMixHidden(ABCabc) => natord::compare(


### PR DESCRIPTION
Before this patch:
```bash
$ mkdir test1 test2 abc 01.city 02.apple
$ touch a.txt abc.txt abc.mp3 ab

$ eza                                       
01.city  02.apple  a.txt  ab  abc  abc.mp3  abc.txt  test1  test2

$ eza --sort=extension                      
ab  abc  test1  test2  02.apple  01.city  abc.mp3  a.txt  abc.txt

$ eza --sort=extension --group-directories-first
abc  test1  test2  02.apple  01.city  ab  abc.mp3  a.txt  abc.txt
```

Note how `01.city` is sorted after `02.apple` when sorting by extension.

After patch:
```bash
$ eza --sort=extension
01.city  02.apple  ab  abc  test1  test2  abc.mp3  a.txt  abc.txt

$ eza --sort=extension --group-directories-first
01.city  02.apple  abc  test1  test2  ab  abc.mp3  a.txt  abc.txt
```
Directories are treated exactly as if there are no `.` was found in the name.

Closes #821