### PR TITLE
chore: Upgrade FreeBSD to 14.3-RELEASE in unit tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Compile
         uses: vmactions/freebsd-vm@v1
         with:
-          release: '14.2'
+          release: '14.3'
           usesh: true
           prepare: |
             pkg install -y curl git


### PR DESCRIPTION
Continuation of https://github.com/eza-community/eza/pull/1522