### PR TITLE
feat: add cb7 filetype

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -98,6 +98,7 @@ const EXTENSION_TYPES: Map<&'static str, FileType> = phf_map! {
     "bmp"        => FileType::Image,
     "cbr"        => FileType::Image,
     "cbz"        => FileType::Image,
+    "cb7"        => FileType::Image,
     "cr2"        => FileType::Image,
     "dvi"        => FileType::Image,
     "eps"        => FileType::Image,

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -542,6 +542,7 @@ const EXTENSION_ICONS: Map<&'static str, char> = phf_map! {
     "catproduct"     => Icons::CAD,              // 󰻫
     "cbr"            => Icons::IMAGE,            // 
     "cbz"            => Icons::IMAGE,            // 
+    "cb7"            => Icons::IMAGE,            // 
     "cc"             => Icons::LANG_CPP,         // 
     "cert"           => Icons::GIST_SECRET,      // 
     "cfg"            => Icons::CONFIG,           // 󱁻


### PR DESCRIPTION
This is the same as the existing cbz and cbr filetypes, except 7zip compressed. See for example https://fileinfo.com/extension/cb7.