### PR TITLE
fix: time_t/Time warnings

### DIFF
--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -32,6 +32,7 @@ pub type ino_t = u64;
 pub type nlink_t = u64;
 
 /// The type of a file’s timestamp (creation, modification, access, etc).
+#[allow(unused)]
 pub type time_t = i64;
 
 /// The type of a file’s user ID.
@@ -207,6 +208,7 @@ pub struct DeviceIDs {
 }
 
 /// One of a file’s timestamps (created, accessed, or modified).
+#[allow(unused)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Time {
     pub seconds: time_t,


### PR DESCRIPTION
Fix the following warnings:

```
warning: type alias `time_t` is never used                                                                                                                    
  --> src/fs/fields.rs:35:10                                                                                                                                  
   |                                                                                                                                                          
35 | pub type time_t = i64;                                                                                                                                   
   |          ^^^^^^                                                                                                                                          
   |                                                                                                                                                          
note: the lint level is defined here                                                                                                                          
  --> src/main.rs:13:9                                                                                                                                        
   |                                                                           
13 | #![warn(unused)]                                                                                                                                         
   |         ^^^^^^                                                                                                                                           
   = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`                                                                                                  
                                                                                                                                                              
warning: struct `Time` is never constructed                                    
   --> src/fs/fields.rs:211:12                                                 
    |                                                                                                                                                         
211 | pub struct Time {                                                                                                                                       
    |            ^^^^                                                                                                                                         
                                                                               
warning: `eza` (bin "eza") generated 2 warnings 
```