### PR TITLE
feat: Implement `--hyperlink=auto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overv
 - **--colo[u]r-scale=(field)**: highlight levels of `field` distinctly(all, age, size)
 - **--color-scale-mode=(mode)**: use gradient or fixed colors in --color-scale. valid options are `fixed` or `gradient`
 - **--icons=(when)**: when to display icons (always, auto, never)
-- **--hyperlink**: display entries as hyperlinks
+- **--hyperlink=(when)**: when to display entries as hyperlinks (always, auto, never)
 - **--absolute=(mode)**: display entries with their absolute path (on, follow, off)
 - **-w**, **--width=(columns)**: set screen width in columns
 

--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -18,6 +18,11 @@ _eza() {
             return
             ;;
 
+        --hyperlink)
+            mapfile -t COMPREPLY < <(compgen -W 'always automatic auto never' -- "$cur")
+            return
+            ;;
+
         -L|--level)
             mapfile -t COMPREPLY < <(compgen -W '{0..9}' -- "$cur")
             return

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -37,7 +37,12 @@ complete -c eza -l icons -d "When to display icons" -x -a "
   never\t'Never display icons'
 "
 complete -c eza -l no-quotes -d "Don't quote file names with spaces"
-complete -c eza -l hyperlink -d "Display entries as hyperlinks"
+complete -c eza -l hyperlink -d "When to display entries as hyperlinks" -x -a "
+  always\t'Always display entries as hyperlinks'
+  auto\t'Display hyperlinks if standard output is a terminal'
+  automatic\t'Display hyperlinks if standard output is a terminal'
+  never\t'Never display entries as hyperlinks'
+"
 complete -c eza -l follow-symlinks -d "Drill down into symbolic links that point to directories"
 complete -c eza -l absolute -d "Display entries with their absolute path" -x -a "
   on\t'Show absolute path for listed entries'

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -17,7 +17,7 @@ export extern "eza" [
     --colour-scale-mode        # Use gradient or fixed colors in --colour-scale
     --icons                    # When to display icons
     --no-quotes                # Don't quote file names with spaces
-    --hyperlink                # Display entries as hyperlinks
+    --hyperlink                # When to display entries as hyperlinks
     --absolute                 # Display entries with their absolute path
     --follow-symlinks          # Drill down into symbolic links that point to directories
     --group-directories-first  # Sort directories before other files

--- a/completions/pwsh/_eza.ps1
+++ b/completions/pwsh/_eza.ps1
@@ -77,6 +77,11 @@ Register-ArgumentCompleter -Native -CommandName 'eza' -ScriptBlock {
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)}
             break
         }
+        '*;--hyperlink' {
+            $ArrayWhen | 
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)}
+            break
+        }
         '*;--all' {
             [CompletionResult]::new('--show-symlinks'            ,'listfilessyl'        , [CompletionResultType]::ParameterName, 'explicitly show symbolic links (for use with --only-dirs | --only-files)')
             [CompletionResult]::new('--no-symlinks'              ,'listfilessyl'        , [CompletionResultType]::ParameterName, 'do not show symbolic links')
@@ -158,7 +163,7 @@ Register-ArgumentCompleter -Native -CommandName 'eza' -ScriptBlock {
         #   [CompletionResult]::new('--colour-scale-mode'        ,'colorscalemode'      , [CompletionResultType]::ParameterName, 'use gradient or fixed colors in --color-scale (fixed, gradient)')
             [CompletionResult]::new('--icons'                    ,'icons'               , [CompletionResultType]::ParameterName, 'when to display icons (always, auto, never)')
             [CompletionResult]::new('--no-quotes'                ,'noquotes'            , [CompletionResultType]::ParameterName, 'don''t quote file names with spaces')
-            [CompletionResult]::new('--hyperlink'                ,'hyperlink'           , [CompletionResultType]::ParameterName, 'display entries as hyperlinks')
+            [CompletionResult]::new('--hyperlink'                ,'hyperlink'           , [CompletionResultType]::ParameterName, 'when to display entries as hyperlinks (always, auto, never)')
             [CompletionResult]::new('--absolute'                 ,'absolute'            , [CompletionResultType]::ParameterName, 'display entries with their absolute path (on, follow, off)')
             [CompletionResult]::new('--follow-symlinks'          ,'followsymlinks'      , [CompletionResultType]::ParameterName, 'drill down into symbolic links that point to directories')
         #   [CompletionResult]::new('-w'                         ,'widths'              , [CompletionResultType]::ParameterName, 'set screen width in columns')

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -25,7 +25,7 @@ __eza() {
         --colo{,u}r-scale-mode"[Use gradient or fixed colors in --color-scale]:(mode):(fixed gradient)" \
         --icons="[When to display icons]:(when):(always auto automatic never)" \
         --no-quotes"[Don't quote filenames with spaces]" \
-        --hyperlink"[Display entries as hyperlinks]" \
+        --hyperlink="[When to display entries as hyperlinks]:(when):(always auto automatic never)" \
         --absolute"[Display entries with their absolute path]:(mode):(on follow off)" \
         --follow-symlinks"[Drill down into symbolic links that point to directories]" \
         --group-directories-first"[Sort directories before other files]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -123,8 +123,13 @@ When used without a value, defaults to ‘`automatic`’.
 `--no-quotes`
 : Don't quote file names with spaces.
 
-`--hyperlink`
+`--hyperlink=WHEN`
 : Display entries as hyperlinks
+
+Valid settings are ‘`always`’, ‘`automatic`’ (‘`auto`’ for short), and ‘`never`’.
+When used without a value, defaults to ‘`automatic`’.
+
+`automatic` or `auto` will display hyperlinks only when the standard output is connected to a real terminal. If `eza` is ran while in a `tty`, or the output of `eza` is either redirected to a file or piped into another program, hyperlinks will not be used. Setting this option to ‘`always`’ causes `eza` to always display hyperlinks, while ‘`never`’ disables the use of hyperlinks.
 
 `-w`, `--width=COLS`
 : Set screen width in columns.

--- a/powertest.yaml
+++ b/powertest.yaml
@@ -70,6 +70,12 @@ commands:
     - --hyperlink
   :
   ? - null
+    - --hyperlink
+  : values:
+      - auto
+      - always
+      - never
+  ? - null
     - --absolute
   : values:
       - on

--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -95,10 +95,10 @@ impl QuoteStyle {
 
 impl EmbedHyperlinks {
     fn deduce(matches: &ArgMatches) -> Self {
-        if matches.get_flag("hyperlink") {
-            Self::On
-        } else {
-            Self::Off
+        match matches.get_one("hyperlink") {
+            Some(ShowWhen::Never) | None => Self::Never,
+            Some(ShowWhen::Always) => Self::Always,
+            Some(ShowWhen::Auto) => Self::Automatic,
         }
     }
 }
@@ -149,18 +149,34 @@ mod tests {
     }
 
     #[test]
-    fn deduce_embed_hyperlinks_on() {
+    fn deduce_embed_hyperlinks_auto() {
         assert_eq!(
             EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink"])),
-            EmbedHyperlinks::On
+            EmbedHyperlinks::Automatic
+        );
+        assert_eq!(
+            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink", "auto"])),
+            EmbedHyperlinks::Automatic
         );
     }
 
     #[test]
-    fn deduce_embed_hyperlinks_off() {
+    fn deduce_embed_hyperlinks_always() {
+        assert_eq!(
+            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink", "always"])),
+            EmbedHyperlinks::Always
+        );
+    }
+
+    #[test]
+    fn deduce_embed_hyperlinks_never() {
+        assert_eq!(
+            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink", "never"])),
+            EmbedHyperlinks::Never
+        );
         assert_eq!(
             EmbedHyperlinks::deduce(&mock_cli(vec![""])),
-            EmbedHyperlinks::Off
+            EmbedHyperlinks::Never
         );
     }
 
@@ -254,7 +270,7 @@ mod tests {
                 classify: Classify::JustFilenames,
                 show_icons: ShowIcons::Never,
                 quote_style: QuoteStyle::QuoteSpaces,
-                embed_hyperlinks: EmbedHyperlinks::Off,
+                embed_hyperlinks: EmbedHyperlinks::Never,
                 absolute: Absolute::Off,
                 is_a_tty: true,
             })

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -85,7 +85,10 @@ pub fn get_command() -> clap::Command {
             .num_args(0..=1)
             .value_parser(value_parser!(ShowWhen))
             .default_missing_value("auto"))
-        .arg(arg!(--hyperlink "display entries as hyperlinks"))
+        .arg(arg!(--hyperlink <WHEN> "when to display entries as hyperlinks")
+            .num_args(0..=1)
+            .value_parser(value_parser!(ShowWhen))
+            .default_missing_value("auto"))
         .arg(arg!(--"no-quotes" "don't quote file names with spaces"))
 
         .next_help_heading("FILTERING OPTIONS")

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -121,8 +121,14 @@ pub enum ShowIcons {
 /// Whether to embed hyperlinks.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum EmbedHyperlinks {
-    Off,
-    On,
+    /// Never embed hyperlinks, even when output is going to a terminal.
+    Never,
+
+    /// Embed hyperlinks automatically, based on the output destination.
+    Automatic,
+
+    /// Always embed hyperlinks, even when the output isn't going to a terminal.
+    Always,
 }
 
 /// Whether to show absolute paths
@@ -275,7 +281,7 @@ impl<C: Colours> FileName<'_, '_, C> {
                             classify: Classify::JustFilenames,
                             quote_style: QuoteStyle::QuoteSpaces,
                             show_icons: ShowIcons::Never,
-                            embed_hyperlinks: EmbedHyperlinks::Off,
+                            embed_hyperlinks: EmbedHyperlinks::Never,
                             is_a_tty: self.options.is_a_tty,
                             absolute: Absolute::Off,
                         };
@@ -413,7 +419,12 @@ impl<C: Colours> FileName<'_, '_, C> {
         let mut bits = Vec::new();
 
         let mut display_hyperlink = false;
-        if self.options.embed_hyperlinks == EmbedHyperlinks::On
+        let should_embed_hyperlinks = match self.options.embed_hyperlinks {
+            EmbedHyperlinks::Never => false,
+            EmbedHyperlinks::Automatic => self.options.is_a_tty,
+            EmbedHyperlinks::Always => true,
+        };
+        if should_embed_hyperlinks
             && let Some(abs_path) = self
                 .file
                 .absolute_path()

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -26,7 +26,7 @@ DISPLAY OPTIONS:
       --color-scale [<FIELDS>...]  highlight value of FIELDS distinctly [possible values: all, age, size]
       --color-scale-mode <MODE>    mode for --color-scale [default: gradient] [possible values: fixed, gradient]
       --icons [<WHEN>]             when to display icons [possible values: always, auto, never]
-      --hyperlink                  display entries as hyperlinks
+      --hyperlink [<WHEN>]         when to display entries as hyperlinks [possible values: always, auto, never]
       --no-quotes                  don't quote file names with spaces
 
 FILTERING OPTIONS:

--- a/tests/ptests/ptest_295b1dd87a9bb792.toml
+++ b/tests/ptests/ptest_295b1dd87a9bb792.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir --hyperlink never"

--- a/tests/ptests/ptest_a689ab7558716dda.stdout
+++ b/tests/ptests/ptest_a689ab7558716dda.stdout
@@ -1,9 +1,0 @@
-]8;;file://[CWD]/tests/test_dir/git/git]8;;/
-]8;;file://[CWD]/tests/test_dir/grid/grid]8;;/
-]8;;file://[CWD]/tests/test_dir/group/group]8;;/
-]8;;file://[CWD]/tests/test_dir/icons/icons]8;;/
-]8;;file://[CWD]/tests/test_dir/perms/perms]8;;/
-]8;;file://[CWD]/tests/test_dir/size/size]8;;/
-]8;;file://[CWD]/tests/test_dir/specials/specials]8;;/
-]8;;file://[CWD]/tests/test_dir/symlinks/symlinks]8;;/
-]8;;file://[CWD]/tests/test_dir/time/time]8;;/

--- a/tests/ptests/ptest_a689ab7558716dda.toml
+++ b/tests/ptests/ptest_a689ab7558716dda.toml
@@ -1,2 +1,0 @@
-bin.name = "eza"
-args = "tests/test_dir --hyperlink "

--- a/tests/ptests/ptest_bba388583551f506.toml
+++ b/tests/ptests/ptest_bba388583551f506.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir --hyperlink always"

--- a/tests/ptests/ptest_e8471ce10a208fd.toml
+++ b/tests/ptests/ptest_e8471ce10a208fd.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir --hyperlink auto"


### PR DESCRIPTION
Implement `--hyperlink=auto/always/never`. This enables `eza` to embed hyperlinks only when printing to a terminal.

Fixes #1093
Fixes #703 