### PR TITLE
fix: implement again PR 1207 (temporarily downgrade palette dependency from v0.7.6 -> v0.7.5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ log = "0.4"
 natord-plus-plus = "2.0"
 path-clean = "1.0.1"
 unit-prefix = "0.5.2"
-palette = { version = "0.7.6", default-features = false, features = ["std"] }
+palette = { version = "0.7.5", default-features = false, features = ["std"] }
 percent-encoding = "2.3.1"
 phf = { version = "0.12.1", features = ["macros"] }
 plist = { version = "1.7.0", default-features = false }


### PR DESCRIPTION
Implement again https://github.com/eza-community/eza/pull/1207 that has been "erased" by accident by https://github.com/eza-community/eza/commit/60ed2f6aadeb1f423a33d67f297351a4cb6c776f commit
Also related: https://github.com/eza-community/eza/issues/1232