### PR TITLE
feat: add --summary flag to display file statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overv
 - **--hyperlink**: display entries as hyperlinks
 - **--absolute=(mode)**: display entries with their absolute path (on, follow, off)
 - **-w**, **--width=(columns)**: set screen width in columns
+- **--summary**: show summary of files, directories, and symlinks
 
 </details>
 

--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -4,7 +4,7 @@ _eza() {
     prev=${COMP_WORDS[COMP_CWORD-1]}
 
     case "$prev" in
-        --help|-v|--version|--smart-group)
+        --help|-v|--version|--smart-group|--summary)
             return
             ;;
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -45,6 +45,7 @@ complete -c eza -l absolute -d "Display entries with their absolute path" -x -a 
   off\t'Do not show the absolute path'
 "
 complete -c eza -l smart-group -d "Only show group if it has a different name from owner"
+complete -c eza -l summary -d "Show summary of files, directories, and symlinks"
 
 # Filtering and sorting options
 complete -c eza -l group-directories-first -d "Sort directories before other files"

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -20,6 +20,7 @@ export extern "eza" [
     --hyperlink                # Display entries as hyperlinks
     --absolute                 # Display entries with their absolute path
     --follow-symlinks          # Drill down into symbolic links that point to directories
+    --summary                  # Show summary of files, directories, and symlinks
     --group-directories-first  # Sort directories before other files
     --group-directories-last   # Sort directories after other files
     --git-ignore               # Ignore files mentioned in '.gitignore'

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -72,7 +72,8 @@ __eza() {
         {-M,--mounts}"[Show mount details (long mode only)]" \
         '*:filename:_files' \
         --smart-group"[Only show group if it has a different name from owner]" \
-        --stdin"[When piping to eza. Read file names from stdin]"
+        --stdin"[When piping to eza. Read file names from stdin]" \
+        --summary"[Show summary of files, directories, and symlinks]"
 }
 
 __eza

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -129,6 +129,11 @@ When used without a value, defaults to ‘`automatic`’.
 `-w`, `--width=COLS`
 : Set screen width in columns.
 
+`--summary`
+: Display a summary showing the count of directories, files, and symlinks at the end of the output.
+
+When used with `--recurse` or `--tree`, the summary includes counts of all items displayed recursively. If the `--icons` option is enabled, the summary will display with corresponding icons next to each category.
+
 FILTERING AND SORTING OPTIONS
 =============================
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,7 @@ fn main() {
                 console_width,
                 git,
                 git_repos,
+                summary: Summary::default(),
             };
 
             info!("matching on exa.run");
@@ -143,6 +144,30 @@ fn main() {
     }
 }
 
+/// Summary statistics for file counts.
+#[derive(Default, Debug)]
+pub struct Summary {
+    pub directories: usize,
+    pub files: usize,
+    pub symlinks: usize,
+}
+
+impl Summary {
+    fn total(&self) -> usize {
+        self.directories + self.files + self.symlinks
+    }
+
+    fn add_file(&mut self, file: &File<'_>) {
+        if file.is_link() {
+            self.symlinks += 1;
+        } else if file.is_directory() {
+            self.directories += 1;
+        } else {
+            self.files += 1;
+        }
+    }
+}
+
 /// The main program wrapper.
 pub struct Exa<'args> {
     /// List of command-line options, having been successfully parsed.
@@ -152,7 +177,7 @@ pub struct Exa<'args> {
     pub writer: io::Stdout,
 
     /// List of the free command-line arguments that should correspond to file
-    /// names (anything that isn’t an option).
+    /// names (anything that isn't an option).
     pub input_paths: Vec<&'args OsStr>,
 
     /// The theme that has been configured from the command-line options and
@@ -170,6 +195,9 @@ pub struct Exa<'args> {
     pub git: Option<GitCache>,
 
     pub git_repos: bool,
+
+    /// Summary statistics tracking.
+    pub summary: Summary,
 }
 
 /// The “real” environment variables type.
@@ -295,7 +323,14 @@ impl Exa<'_> {
         self.options.filter.filter_argument_files(&mut files);
         self.print_files(None, files)?;
 
-        self.print_dirs(dirs, no_files, is_only_dir, exit_status)
+        let exit_code = self.print_dirs(dirs, no_files, is_only_dir, exit_status)?;
+        
+        // Print summary if enabled
+        if self.options.view.summary {
+            self.print_summary()?;
+        }
+        
+        Ok(exit_code)
     }
 
     fn print_dirs(
@@ -414,11 +449,54 @@ impl Exa<'_> {
         Ok(exit_status)
     }
 
+    /// Recursively count files in a directory for tree/recursive modes
+    fn count_files_recursive(&mut self, file: &File<'_>) {
+        self.summary.add_file(file);
+        
+        if file.is_directory() {
+            if let Ok(dir) = file.read_dir() {
+                let git_ignore = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
+                // Collect files first to avoid borrow checker issues
+                let children: Vec<_> = dir.files(
+                    self.options.filter.dot_filter,
+                    self.git.as_ref(),
+                    git_ignore,
+                    self.options.view.deref_links,
+                    self.options.view.total_size,
+                ).collect();
+                
+                for child in children {
+                    self.count_files_recursive(&child);
+                }
+            }
+        }
+    }
+    
     /// Prints the list of files using whichever view is selected.
     fn print_files(&mut self, dir: Option<&Dir>, mut files: Vec<File<'_>>) -> io::Result<()> {
         if files.is_empty() {
             return Ok(());
         }
+        
+        // Count files for summary if enabled
+        if self.options.view.summary {
+            let is_tree_mode = self.options.dir_action.recurse_options()
+                .map(|r| r.tree)
+                .unwrap_or(false);
+            
+            if is_tree_mode {
+                // In tree mode, we need to recursively count all files
+                for file in &files {
+                    self.count_files_recursive(file);
+                }
+            } else {
+                // In other modes, just count the files being printed
+                for file in &files {
+                    self.summary.add_file(file);
+                }
+            }
+        }
+        
         let recursing = self.options.dir_action.recurse_options().is_some();
         let only_files = self.options.filter.flags.contains(&OnlyFiles);
         if recursing && only_files {
@@ -542,6 +620,35 @@ impl Exa<'_> {
                 r.render(&mut self.writer)
             }
         }
+    }
+
+    /// Print the summary statistics.
+    fn print_summary(&mut self) -> io::Result<()> {
+        use crate::output::file_name::ShowIcons;
+        
+        writeln!(&mut self.writer)?;
+        
+        let show_icons = match self.options.view.file_style.show_icons {
+            ShowIcons::Always(_) => true,
+            ShowIcons::Automatic(_) => io::stdout().is_terminal(),
+            ShowIcons::Never => false,
+        };
+        
+        if show_icons {
+            // With icons
+            writeln!(&mut self.writer, "  \u{e5ff} Directories: {}", self.summary.directories)?;
+            writeln!(&mut self.writer, "  \u{f15b} Files: {}", self.summary.files)?;
+            writeln!(&mut self.writer, "  \u{f0338} Symlinks: {}", self.summary.symlinks)?;
+        } else {
+            // Without icons
+            writeln!(&mut self.writer, "  Directories: {}", self.summary.directories)?;
+            writeln!(&mut self.writer, "  Files: {}", self.summary.files)?;
+            writeln!(&mut self.writer, "  Symlinks: {}", self.summary.symlinks)?;
+        }
+        
+        writeln!(&mut self.writer, "Total: {}", self.summary.total())?;
+        
+        Ok(())
     }
 }
 

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -24,6 +24,7 @@ pub static WIDTH:        Arg = Arg { short: Some(b'w'), long: "width",          
 pub static NO_QUOTES:    Arg = Arg { short: None,       long: "no-quotes",       takes_value: TakesValue::Forbidden };
 pub static ABSOLUTE:     Arg = Arg { short: None,       long: "absolute",        takes_value: TakesValue::Optional(Some(ABSOLUTE_MODES), "on") };
 pub static FOLLOW_LINKS: Arg = Arg { short: None,       long: "follow-symlinks", takes_value: TakesValue::Forbidden };
+pub static SUMMARY:      Arg = Arg { short: None,       long: "summary",         takes_value: TakesValue::Forbidden };
 const ABSOLUTE_MODES: &[&str] = &["on", "follow", "off"];
 
 pub static COLOR:  Arg = Arg { short: None, long: "color",  takes_value: TakesValue::Optional(Some(WHEN), "auto") };
@@ -103,7 +104,7 @@ pub static ALL_ARGS: Args = Args(&[
 
     &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY, &DEREF_LINKS, &FOLLOW_LINKS,
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE, &COLOR_SCALE_MODE, &COLOUR_SCALE_MODE,
-    &WIDTH, &NO_QUOTES, &ABSOLUTE,
+    &WIDTH, &NO_QUOTES, &ABSOLUTE, &SUMMARY,
 
     &ALL, &ALMOST_ALL, &TREAT_DIRS_AS_FILES, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST, &DIRS_LAST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS, &ONLY_FILES,

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -35,6 +35,7 @@ DISPLAY OPTIONS
   --absolute                 display entries with their absolute path (on, follow, off)
   --follow-symlinks          drill down into symbolic links that point to directories
   -w, --width COLS           set screen width in columns
+  --summary                  show summary of files, directories, and symlinks
 
 
 FILTERING AND SORTING OPTIONS

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -26,6 +26,7 @@ impl View {
         let deref_links = matches.has(&flags::DEREF_LINKS)?;
         let follow_links = matches.has(&flags::FOLLOW_LINKS)?;
         let total_size = matches.has(&flags::TOTAL_SIZE)?;
+        let summary = matches.has(&flags::SUMMARY)?;
         let file_style = FileStyle::deduce(matches, vars, is_tty)?;
         Ok(Self {
             mode,
@@ -34,6 +35,7 @@ impl View {
             deref_links,
             follow_links,
             total_size,
+            summary,
         })
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -32,6 +32,7 @@ pub struct View {
     pub deref_links: bool,
     pub follow_links: bool,
     pub total_size: bool,
+    pub summary: bool,
 }
 
 /// The **mode** is the “type” of output.


### PR DESCRIPTION
## Description

This PR adds a new \`--summary\` flag that displays a summary of file counts at the end of eza's output.

## Changes

- **New flag**: \`--summary\` (no short flag, as \`-s\` is used by \`--sort\`)
- **Summary display**: Shows counts of directories, files, and symlinks, plus total
- **Icon support**: Respects the \`--icons\` flag setting
- **Recursive counting**: Works correctly with both \`--recurse\` and \`--tree\` modes

## Testing

Tested with:
- Basic usage: \`eza --summary\`
- With icons: \`eza --summary --icons=always\`
- Without icons: \`eza --summary --icons=never\`
- Recursive mode: \`eza --summary --recurse\`
- Tree mode: \`eza --summary --tree\`
- Long view: \`eza --summary --long\`

Example output with icons:
```
    Directories: 4
    Files: 4
    Symlinks: 1
Total: 9
```

Example output without icons:
```
  Directories: 4
  Files: 4
  Symlinks: 1
Total: 9
```

## Checklist

- [x] Added completions for bash, zsh, fish, nushell
- [x] Added documentation to the man page
- [x] Added option to the help flag
- [x] Added option to the README.md
- [x] Follows conventional commits
- [x] Code compiles without warnings
- [x] No linter errors
- [x] Tested locally and works as expected