### PR TITLE
fix: color code parsing in theme.yml

### DIFF
--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -91,7 +91,7 @@ fn color_from_str(s: &str) -> Option<Color> {
                 Some(Rgb(r, g, b))
             },
             // #rgb shorthand hex color
-            ['#', r, g, b]              => {
+            ['#', r, g, b] => {
                 let Ok(r) = u8::from_str_radix(&format!("{r}{r}"), 16)
                     else { return None };
                 let Ok(g) = u8::from_str_radix(&format!("{g}{g}"), 16)
@@ -100,9 +100,19 @@ fn color_from_str(s: &str) -> Option<Color> {
                     else { return None };
                 Some(Rgb(r, g, b))
             },
-            // 0-255 color code
+            // 0-255 color code (1-3 digits)
+            [c1] => {
+                let Ok(c) = str::parse::<u8>(&format!("{c1}"))
+                    else { return None };
+                Some(Fixed(c))
+            },
             [c1, c2] => {
                 let Ok(c) = str::parse::<u8>(&format!("{c1}{c2}"))
+                    else { return None };
+                Some(Fixed(c))
+            },
+            [c1, c2, c3] => {
+                let Ok(c) = str::parse::<u8>(&format!("{c1}{c2}{c3}"))
                     else { return None };
                 Some(Fixed(c))
             },
@@ -662,7 +672,7 @@ mod tests {
 
     #[test]
     fn parse_color_code_from_string() {
-        for (s, c) in &[("10", 10), ("01", 1)] {
+        for (s, c) in &[("118", 118), ("10", 10), ("01", 1), ("1", 1), ("001", 1)] {
             assert_eq!(color_from_str(s), Some(Color::Fixed(*c)));
         }
     }


### PR DESCRIPTION
for whatever reason, when implemented in #1111, ['fixed'](https://docs.rs/nu-ansi-term/latest/nu_ansi_term/enum.Color.html#variant.Fixed) color was only able to be parsed from two-digit numbers (so, only 0 to 99 [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg) were usable).

---

for this PR:
- I'm not super familiar with conventional commits, sorry! would adding a `:` after `fix` be enough? :slightly_smiling_face: 
- regarding `CHANGELOG.md`: I'm pretty sure this needs to be documented there... right?