### PR TITLE
refactor: change 'new' to 'untracked' for clippy

### DIFF
--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -368,7 +368,7 @@ fn reorient(path: &Path) -> PathBuf {
 fn working_tree_status(status: git2::Status) -> f::GitStatus {
     #[rustfmt::skip]
     return match status {
-        s if s.contains(git2::Status::WT_NEW)         => f::GitStatus::New,
+        s if s.contains(git2::Status::WT_NEW)         => f::GitStatus::Untracked,
         s if s.contains(git2::Status::WT_MODIFIED)    => f::GitStatus::Modified,
         s if s.contains(git2::Status::WT_DELETED)     => f::GitStatus::Deleted,
         s if s.contains(git2::Status::WT_RENAMED)     => f::GitStatus::Renamed,
@@ -384,7 +384,7 @@ fn working_tree_status(status: git2::Status) -> f::GitStatus {
 fn index_status(status: git2::Status) -> f::GitStatus {
     #[rustfmt::skip]
     return match status {
-        s if s.contains(git2::Status::INDEX_NEW)         => f::GitStatus::New,
+        s if s.contains(git2::Status::INDEX_NEW)         => f::GitStatus::Untracked,
         s if s.contains(git2::Status::INDEX_MODIFIED)    => f::GitStatus::Modified,
         s if s.contains(git2::Status::INDEX_DELETED)     => f::GitStatus::Deleted,
         s if s.contains(git2::Status::INDEX_RENAMED)     => f::GitStatus::Renamed,

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -216,7 +216,7 @@ pub enum GitStatus {
 
     /// This file didn’t exist for the last commit, and is not specified in
     /// the ignored files list.
-    New,
+    Untracked,
 
     /// A file that’s been modified since the last commit.
     Modified,

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -434,7 +434,7 @@ impl FromOverride<LinksOverride> for Links {
 #[rustfmt::skip]
 #[derive(Clone, Copy, Debug,Eq, PartialEq, Serialize, Deserialize)]
 pub struct GitOverride {
-    pub new: Option<StyleOverride>,         // ga
+    pub untracked: Option<StyleOverride>,   // ga
     pub modified: Option<StyleOverride>,    // gm
     pub deleted: Option<StyleOverride>,     // gd
     pub renamed: Option<StyleOverride>,     // gv
@@ -446,7 +446,7 @@ pub struct GitOverride {
 impl FromOverride<GitOverride> for Git {
     fn from(value: GitOverride, default: Self) -> Self {
         Git {
-            new: FromOverride::from(value.new, default.new),
+            untracked: FromOverride::from(value.untracked, default.untracked),
             modified: FromOverride::from(value.modified, default.modified),
             deleted: FromOverride::from(value.deleted, default.deleted),
             renamed: FromOverride::from(value.renamed, default.renamed),

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -23,7 +23,7 @@ impl f::GitStatus {
         #[rustfmt::skip]
         return match self {
             Self::NotModified  => colours.not_modified().paint("-"),
-            Self::New          => colours.new().paint("N"),
+            Self::New          => colours.untracked().paint("N"),
             Self::Modified     => colours.modified().paint("M"),
             Self::Deleted      => colours.deleted().paint("D"),
             Self::Renamed      => colours.renamed().paint("R"),
@@ -36,10 +36,7 @@ impl f::GitStatus {
 
 pub trait Colours {
     fn not_modified(&self) -> Style;
-    // FIXME: this amount of allows needed to keep clippy happy should be enough
-    // of an argument that new needs to be renamed.
-    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
-    fn new(&self) -> Style;
+    fn untracked(&self) -> Style;
     fn modified(&self) -> Style;
     fn deleted(&self) -> Style;
     fn renamed(&self) -> Style;
@@ -110,7 +107,7 @@ pub mod test {
         fn not_modified(&self) -> Style {
             Fixed(90).normal()
         }
-        fn new(&self) -> Style {
+        fn untracked(&self) -> Style {
             Fixed(91).normal()
         }
         fn modified(&self) -> Style {

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -23,7 +23,7 @@ impl f::GitStatus {
         #[rustfmt::skip]
         return match self {
             Self::NotModified  => colours.not_modified().paint("-"),
-            Self::New          => colours.untracked().paint("N"),
+            Self::Untracked     => colours.untracked().paint("N"),
             Self::Modified     => colours.modified().paint("M"),
             Self::Deleted      => colours.deleted().paint("D"),
             Self::Renamed      => colours.renamed().paint("R"),
@@ -148,7 +148,7 @@ pub mod test {
     #[test]
     fn git_new_changed() {
         let stati = f::Git {
-            staged: f::GitStatus::New,
+            staged: f::GitStatus::Untracked,
             unstaged: f::GitStatus::Modified,
         };
 

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -83,7 +83,7 @@ impl Default for UiStyles {
 
             #[rustfmt::skip]
             git: Some(Git {
-                new:         Some(Green.normal()),
+                untracked:   Some(Green.normal()),
                 modified:    Some(Blue.normal()),
                 deleted:     Some(Red.normal()),
                 renamed:     Some(Yellow.normal()),

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -363,8 +363,7 @@ impl render::FiletypeColours for Theme {
 #[rustfmt::skip]
 impl render::GitColours for Theme {
     fn not_modified(&self)  -> Style { self.ui.punctuation() }
-    #[allow(clippy::new_ret_no_self)]
-    fn new(&self)           -> Style { self.ui.git.unwrap_or_default().new() }
+    fn untracked(&self)     -> Style { self.ui.git.unwrap_or_default().untracked() }
     fn modified(&self)      -> Style { self.ui.git.unwrap_or_default().modified() }
     fn deleted(&self)       -> Style { self.ui.git.unwrap_or_default().deleted() }
     fn renamed(&self)       -> Style { self.ui.git.unwrap_or_default().renamed() }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -704,7 +704,7 @@ mod customs_test {
     test!(exa_lc:  ls "", exa "lc=38;5;121"  =>  colours c -> { c.links().normal                          = Some(Fixed(121).normal()); });
     test!(exa_lm:  ls "", exa "lm=38;5;122"  =>  colours c -> { c.links().multi_link_file                 = Some(Fixed(122).normal()); });
 
-    test!(exa_ga:  ls "", exa "ga=38;5;123"  =>  colours c -> { c.git().new                               = Some(Fixed(123).normal()); });
+    test!(exa_ga:  ls "", exa "ga=38;5;123"  =>  colours c -> { c.git().untracked                          = Some(Fixed(123).normal()); });
     test!(exa_gm:  ls "", exa "gm=38;5;124"  =>  colours c -> { c.git().modified                          = Some(Fixed(124).normal()); });
     test!(exa_gd:  ls "", exa "gd=38;5;125"  =>  colours c -> { c.git().deleted                           = Some(Fixed(125).normal()); });
     test!(exa_gv:  ls "", exa "gv=38;5;126"  =>  colours c -> { c.git().renamed                           = Some(Fixed(126).normal()); });

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -297,6 +297,13 @@ impl Default for Git {
     }
 }
 
+impl Git {
+    #[must_use]
+    pub fn untracked(&self) -> Style {
+        self.new()
+    }
+}
+
 #[rustfmt::skip]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GitRepo {

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -264,7 +264,7 @@ field_accessors!(Links, normal: Option<Style>, multi_link_file: Option<Style>);
 #[rustfmt::skip]
 #[derive(Clone, Copy, Debug,Eq, PartialEq, Serialize, Deserialize)]
 pub struct Git {
-    pub new: Option<Style>,         // ga
+    pub untracked: Option<Style>,   // ga
     pub modified: Option<Style>,    // gm
     pub deleted: Option<Style>,     // gd
     pub renamed: Option<Style>,     // gv
@@ -275,7 +275,7 @@ pub struct Git {
 
 field_accessors!(
     Git,
-    new: Option<Style>,
+    untracked: Option<Style>,
     modified: Option<Style>,
     deleted: Option<Style>,
     renamed: Option<Style>,
@@ -286,7 +286,7 @@ field_accessors!(
 impl Default for Git {
     fn default() -> Self {
         Git {
-            new: Some(Green.normal()),
+            untracked: Some(Green.normal()),
             modified: Some(Blue.normal()),
             deleted: Some(Red.normal()),
             renamed: Some(Yellow.normal()),
@@ -294,13 +294,6 @@ impl Default for Git {
             ignored: Some(Style::default().dimmed()),
             conflicted: Some(Red.normal()),
         }
-    }
-}
-
-impl Git {
-    #[must_use]
-    pub fn untracked(&self) -> Style {
-        self.new()
     }
 }
 
@@ -452,7 +445,7 @@ impl UiStyles {
 
             #[rustfmt::skip]
             git: Some(Git {
-                new:         Some(Style::default()),
+                untracked:   Some(Style::default()),
                 modified:    Some(Style::default()),
                 deleted:     Some(Style::default()),
                 renamed:     Some(Style::default()),
@@ -584,7 +577,7 @@ impl UiStyles {
             "lc" => self.links().normal                   = Some(pair.to_style()),
             "lm" => self.links().multi_link_file          = Some(pair.to_style()),
 
-            "ga" => self.git().new                        = Some(pair.to_style()),
+            "ga" => self.git().untracked                   = Some(pair.to_style()),
             "gm" => self.git().modified                   = Some(pair.to_style()),
             "gd" => self.git().deleted                    = Some(pair.to_style()),
             "gv" => self.git().renamed                    = Some(pair.to_style()),


### PR DESCRIPTION
Resolves a FIXME comment about the `new` method on a few structs. Clippy was flagging that these ones aren't constructors, as they don't return `Self`, so this PR renames those methods to `untracked`, which is clearer about intent and less confusing with the conventions.