### PR TITLE
fix: ensure that /dev/null as stdin works.

### DIFF
--- a/src/options/stdin.rs
+++ b/src/options/stdin.rs
@@ -18,9 +18,33 @@ pub enum FilesInput {
     Args,
 }
 
+// Check if stdin is redirected to /dev/null.
+// /dev/null is commonly used in sandboxes and background processes to mean "no input",
+// so we should not try to read from it.
+#[cfg(unix)]
+fn is_stdin_dev_null() -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let Ok(stdin_meta) = std::fs::metadata("/dev/stdin") else {
+        return false;
+    };
+    let Ok(null_meta) = std::fs::metadata("/dev/null") else {
+        return false;
+    };
+
+    // Compare device and inode numbers to check if stdin is /dev/null
+    stdin_meta.dev() == null_meta.dev() && stdin_meta.ino() == null_meta.ino()
+}
+
+#[cfg(not(unix))]
+fn is_stdin_dev_null() -> bool {
+    // On non-Unix platforms, we can't reliably detect /dev/null
+    false
+}
+
 impl FilesInput {
     pub fn deduce<V: Vars>(matches: &ArgMatches, vars: &V) -> Self {
-        if matches.get_flag("stdin") || !io::stdin().is_terminal() {
+        if matches.get_flag("stdin") || (!io::stdin().is_terminal() && !is_stdin_dev_null()) {
             let separator = vars
                 .get(EZA_STDIN_SEPARATOR)
                 .unwrap_or(OsString::from("\n"));


### PR DESCRIPTION
If you had stdin linked to /dev/null no output would be returned, as a check for whether stdin was a terminal would fail. Now the problem is that many sandboxes (e.g. claude code sandbox) redirect stdin to /dev/null so when running under those conditions `eza` would return no output.

Fixes https://github.com/eza-community/eza/issues/1725.

Note: see issue for more detail, and a suggested alternative approach.