### PR TITLE
docs: fix man page cross-references

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -343,7 +343,7 @@ See `https://no-color.org/` for details.
 
 Specifies the colour scheme used to highlight files based on their name and kind, as well as highlighting metadata and parts of the UI.
 
-For more information on the format of these environment variables, see the [eza_colors.5.md](eza_colors.5.md) manual page.
+For more information on the format of these environment variables, see the [eza_colors.5.md](eza_colors.5) manual page.
 
 ## `EZA_OVERRIDE_GIT`
 
@@ -395,5 +395,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza_colors**(5)](eza_colors.5.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+- [**eza_colors**(5)](eza_colors.5)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5)

--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -399,5 +399,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza**(1)](eza.1.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+- [**eza**(1)](eza.1)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5)


### PR DESCRIPTION
Fixes #981

Removes `.md` suffixes from SEE ALSO cross-references in man pages.
- eza.1.md: Fixed references to eza_colors.5 and eza_colors-explanation.5
- eza_colors.5.md: Fixed references to eza.1 and eza_colors-explanation.5