### PR TITLE
fix: Detect mounts even without /proc

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -403,11 +403,24 @@ impl<'dir> File<'dir> {
 
     /// Whether this file is a mount point
     pub fn is_mount_point(&self) -> bool {
-        cfg!(any(target_os = "linux", target_os = "macos"))
-            && self.is_directory()
-            && self
+        if cfg!(not(any(target_os = "linux", target_os = "macos"))) || !self.is_directory() {
+            return false;
+        }
+        let all_mounts = all_mounts();
+        if !all_mounts.is_empty() {
+            return self
                 .absolute_path()
-                .is_some_and(|p| all_mounts().contains_key(p))
+                .is_some_and(|p| all_mounts.contains_key(p));
+        }
+        #[cfg(unix)]
+        if let Ok(x) = std::fs::metadata(&self.path)
+            && let Ok(y) = std::fs::metadata(self.path.join(".."))
+        {
+            // .dev() is the traditional fallback used by mountpoint(1). Misses bind mounts.
+            // .ino() detects the root directory, which parents itself and is always a mount
+            return x.dev() != y.dev() || x.ino() == y.ino();
+        }
+        false
     }
 
     /// The filesystem device and type for a mount point


### PR DESCRIPTION
The traditional way to detect mountpoints is to compare the device IDs containing the directory and its parent. mountpoint(1) uses this if it cannot open `/proc/self/mountinfo`.

# Before

The underlines are missing when `/proc` is not properly mounted.

<img width="1065" height="1085" alt="underlines missing" src="https://github.com/user-attachments/assets/d979ce06-50d6-4726-9241-2922aa969aaf" />

# After

The underlines are still present without a functioning `/proc`.

<img width="1371" height="1084" alt="underlines present" src="https://github.com/user-attachments/assets/c6f2829a-3763-45bc-aa80-6863226db264" />