### PR TITLE
ci: add riscv64 to release binaries

### DIFF
--- a/justfile
+++ b/justfile
@@ -269,6 +269,9 @@ alias c := cross
     just binary_no_libgit eza arm-unknown-linux-gnueabihf
     # just binary_static eza arm-unknown-linux-gnueabihf
 
+    ### riscv64
+    just binary eza riscv64gc-unknown-linux-gnu
+
     ## MacOS
     # TODO: just binary eza x86_64-apple-darwin
 


### PR DESCRIPTION
Add `riscv64gc-unknown-linux-gnu` to the cross-compilation targets in `justfile`, as suggested in #1748.

RISE runner build evidence: https://github.com/gounthar/eza/actions/runs/23428297970