### PR TITLE
fix(stdin): default to current dir on empty implicit stdin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,10 @@ fn main() {
                                 .filter(|s| !s.is_empty())
                                 .collect::<Vec<_>>(),
                         );
+
+                        if input.is_empty() && !cli.get_flag("stdin") {
+                            input_paths = vec![OsStr::new(".")];
+                        }
                     }
                 }
             }

--- a/tests/stdin_dev_null.rs
+++ b/tests/stdin_dev_null.rs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 eza contributors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+#[cfg(unix)]
+mod tests {
+    use std::fs;
+    use std::process::{Command, Stdio};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir() -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("eza-stdin-dev-null-{unique}"));
+        fs::create_dir(&path).expect("should create temp directory");
+        path
+    }
+
+    #[test]
+    fn defaults_to_current_directory_when_stdin_is_empty_and_not_explicitly_requested() {
+        let path = temp_dir();
+        fs::create_dir(path.join("alpha")).expect("should create alpha directory");
+        fs::write(path.join("file.txt"), "").expect("should create file");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_eza"))
+            .args(["--oneline", "--icons=never", "--color=never"])
+            .current_dir(&path)
+            .stdin(Stdio::null())
+            .output()
+            .expect("eza should run");
+
+        fs::remove_dir_all(&path).expect("should remove temp directory");
+
+        assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "alpha\nfile.txt\n");
+    }
+
+    #[test]
+    fn explicit_stdin_still_uses_stdin_even_when_it_is_empty() {
+        let path = temp_dir();
+        fs::create_dir(path.join("alpha")).expect("should create alpha directory");
+        fs::write(path.join("file.txt"), "").expect("should create file");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_eza"))
+            .args(["--stdin", "--oneline", "--icons=never", "--color=never"])
+            .current_dir(&path)
+            .stdin(Stdio::null())
+            .output()
+            .expect("eza should run");
+
+        fs::remove_dir_all(&path).expect("should remove temp directory");
+
+        assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.stdout.is_empty(), "stdout: {}", String::from_utf8_lossy(&output.stdout));
+    }
+}


### PR DESCRIPTION
##### Description
Fixes #1725.

When `eza` is invoked without file arguments, it auto-reads stdin whenever stdin is non-terminal. If that implicit stdin read is truly empty, `input_paths` stays empty and `eza` exits without listing anything.

This change keeps explicit `--stdin` behavior as-is, but falls back to `.` when stdin was only read implicitly and the read returned an empty string. That preserves the intended pipe behavior while fixing the empty-stdin `/dev/null` case.

##### How Has This Been Tested?
- `rustup run 1.90-aarch64-apple-darwin cargo test --test stdin_dev_null`
- Manual repro before/after with the built binary in a temp directory:
  - before: `target/debug/eza --oneline --icons=never --color=never < /dev/null` produced no output
  - after: the same command listed the current directory
  - `target/debug/eza --stdin --oneline --icons=never --color=never < /dev/null` still produced no output
- `git diff --check`
