### PR TITLE
fix: validate --time field value, error on invalid input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ SPDX-License-Identifier: EUPL-1.2
 -->
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Validate `--time` / `-t` field value and error on invalid input instead of silently consuming positional arguments
+
 ## [0.23.4] - 2025-10-03
 
 ### Bug Fixes

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -448,6 +448,21 @@ impl TimeTypes {
     /// see the default set.
     fn deduce(matches: &ArgMatches) -> Result<Self, OptionsError> {
         let possible_word = matches.get_one::<TimeArgs>("time");
+
+        // clap's value_parser for a manually-implemented ValueEnum may not enforce
+        // validation, causing invalid values (e.g. filenames from glob expansion) to
+        // be silently accepted and discarded, resulting in missing output files.
+        if possible_word.is_none() {
+            if let Some(mut raw) = matches.get_raw("time") {
+                if let Some(val) = raw.next() {
+                    return Err(OptionsError::Unsupported(format!(
+                        "Invalid argument for --time: '{}', expected one of: modified, accessed, created, changed",
+                        val.to_string_lossy()
+                    )));
+                }
+            }
+        }
+
         let modified = matches.get_flag("modified");
         let changed = matches.get_flag("changed");
         let accessed = matches.get_flag("accessed");


### PR DESCRIPTION
Fixes #1740

## Problem

`eza -t *.md` silently consumes the first filename from glob expansion as the `--time` field value, shows one fewer file, and exits 0. Anyone with `alias ls=eza` who runs `ls -t *.md` in a script will silently lose the first file — a dangerous footgun with no warning.

```bash
$ touch a.md b.md c.md d.md
$ ls -t *.md | wc -l   # 4 (correct)
$ eza -t *.md | wc -l  # 3 (a.md consumed as --time field, missing from output)
```

## Fix

After `matches.get_one::<TimeArgs>("time")` returns `None`, check `matches.get_raw("time")` to detect when `--time` was provided but its value failed to parse as a valid `TimeArgs` variant. Return a descriptive error with the valid choices.

This is a version-independent defense: in newer clap builds the `EnumValueParser` already catches this at argument parsing time; the explicit `get_raw` check ensures correct behavior regardless of clap version.

## Result

```bash
$ eza -t *.md
error: invalid value 'a.md' for '--time <FIELD>'
  [possible values: modified, changed, accessed, created]
```

## Test plan

- [ ] `eza -t *.md` → error listing valid values (no silent file loss)
- [ ] `eza -t modified *.md` → correct output, all files shown
- [ ] `eza -t "garbage"` → error with valid choices
- [ ] `eza -t` (no value) → existing clap error unchanged