### PR TITLE
fix: prevent double timezone conversion causing dates off by one day

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -777,7 +777,7 @@ impl<'dir> File<'dir> {
             duration.as_secs().try_into().ok()?,
             (duration.as_nanos() % 1_000_000_000).try_into().ok()?,
         )
-        .map(|dt| dt.naive_local())
+        .map(|dt| dt.naive_utc())
     }
 
     /// This file’s last modified timestamp, if available on this platform.


### PR DESCRIPTION
## Problem

Files display timestamps one day in the past for users in positive UTC offset timezones (e.g. UTC+2, UTC+5:30).

Fixes #1674

## Root Cause

`systemtime_to_naivedatetime()` in `src/fs/file.rs` calls `.naive_local()` on a UTC `DateTime`, converting UTC → local time and storing the result as a `NaiveDateTime` (which carries no timezone info).

Later, the render layer in `src/output/render/times.rs` calls:
```rust
DateTime::<FixedOffset>::from_naive_utc_and_offset(time, time_offset)
```

This function's contract is that the input `NaiveDateTime` is **UTC**, but the value was already local time — so the timezone offset is applied a second time, pushing the displayed date further into the past.

**Example:** A file modified at `2024-04-19 01:30 UTC+2` (= `2024-04-18 23:30 UTC`) would:
1. Be stored as `NaiveDateTime(2024-04-19 01:30)` (via `naive_local()`)
2. Then displayed as `2024-04-19 01:30 + 02:00 = 2024-04-19 03:30` — actually correct in this case, but for files near midnight the day rolls over

Actually the more common symptom: a file modified at `2024-04-18 23:00 UTC` in UTC+2 timezone:
1. `naive_local()` → `NaiveDateTime(2024-04-19 01:00)` ✓
2. `from_naive_utc_and_offset(..., +02:00)` treats it as UTC `2024-04-19 01:00` and adds 2h → displays `2024-04-19 03:00` ✗

The date is wrong; the offset is applied twice.

## Fix

Store the `NaiveDateTime` as UTC by using `.naive_utc()` instead of `.naive_local()`. The render layer then correctly applies the timezone offset exactly once for display.

```diff
-        .map(|dt| dt.naive_local())
+        .map(|dt| dt.naive_utc())
```

## Testing

Verified that `cargo build` succeeds. Manually tested: files with known modification times now display the correct local date/time.