### PR TITLE
PR 1 of 2 for improving hidden-entry behavior on Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ uzers = "0.12.1"
 windows-sys = { version = "0.61.2", features = [
   "Win32_System_Console",
   "Win32_Foundation",
+  "Win32_Storage_FileSystem",
 ] }
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overv
 <summary>Click to expand</summary>
 
 - **-a**, **--all**: show hidden and 'dot' files
+- **--show-dotfiles**: show dot-prefixed files without showing other hidden files
 - **-d**, **--treat-dirs-as-files**: list directories like regular files
 - **-L**, **--level=(depth)**: limit the depth of recursion
 - **-r**, **--reverse**: reverse the sort order

--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -4,7 +4,7 @@ _eza() {
     prev=${COMP_WORDS[COMP_CWORD-1]}
 
     case "$prev" in
-        --help|-v|--version|--smart-group)
+        --help|-v|--version|--smart-group|--show-dotfiles)
             return
             ;;
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -57,6 +57,7 @@ complete -c eza -l group-directories-last -d "Sort directories after other files
 complete -c eza -l git-ignore -d "Ignore files mentioned in '.gitignore'"
 complete -c eza -s a -l all -d "Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories"
 complete -c eza -s A -l almost-all -d "Equivalent to --all; included for compatibility with `ls -A`"
+complete -c eza -l show-dotfiles -d "Show dot-prefixed files without showing other hidden files"
 complete -c eza -s d -l treat-dirs-as-files -d "List directories like regular files"
 complete -c eza -s L -l level -d "Limit the depth of recursion" -x -a "1 2 3 4 5 6 7 8 9"
 complete -c eza -s w -l width -d "Limits column output of grid, 0 implies auto-width"

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -25,6 +25,7 @@ export extern "eza" [
     --git-ignore               # Ignore files mentioned in '.gitignore'
     --all(-a)                  # Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories
     --almost-all(-A)           # Equivalent to --all; included for compatibility with `ls -A`
+    --show-dotfiles            # Show dot-prefixed files without showing other hidden files
     --treat-dirs-as-files(-d)  # List directories like regular files
     --level(-L): string        # Limit the depth of recursion
     --width(-w)                # Limits column output of grid, 0 implies auto-width

--- a/completions/pwsh/_eza.ps1
+++ b/completions/pwsh/_eza.ps1
@@ -172,6 +172,7 @@ Register-ArgumentCompleter -Native -CommandName 'eza' -ScriptBlock {
             [CompletionResult]::new('--all'                      ,'filter'              , [CompletionResultType]::ParameterName, 'show hidden and ''dot'' files. Use this twice to also show the ''.'' and ''..'' directories')
         #   [CompletionResult]::new('-A'                         ,'filter'              , [CompletionResultType]::ParameterName, 'equivalent to --all; included for compatibility with `ls -A`')
         #   [CompletionResult]::new('--almost-all'               ,'filter'              , [CompletionResultType]::ParameterName, 'equivalent to --all; included for compatibility with `ls -A`')
+            [CompletionResult]::new('--show-dotfiles'            ,'filter'              , [CompletionResultType]::ParameterName, 'show dot-prefixed files without showing other hidden files')
         #   [CompletionResult]::new('-d'                         ,'filter'              , [CompletionResultType]::ParameterName, 'list directories as files; don''t list their contents')
             [CompletionResult]::new('--treat-dirs-as-files'      ,'filter'              , [CompletionResultType]::ParameterName, 'list directories as files; don''t list their contents')
         #   [CompletionResult]::new('-D'                         ,'filter'              , [CompletionResultType]::ParameterName, 'list only directories')

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -33,6 +33,7 @@ __eza() {
         --git-ignore"[Ignore files mentioned in '.gitignore']" \
         {-a,--all}"[Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories]" \
         {-A,--almost-all}"[Equivalent to --all; included for compatibility with \'ls -A\']" \
+        --show-dotfiles"[Show dot-prefixed files without showing other hidden files]" \
         {-d,--treat-dirs-as-files}"[List directories like regular files]" \
         {-D,--only-dirs}"[List only directories]" \
         --no-symlinks"[Do not show symbolic links]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -144,6 +144,9 @@ Use this twice to also show the ‘`.`’ and ‘`..`’ directories.
 `-A`, `--almost-all`
 : Equivalent to --all; included for compatibility with `ls -A`.
 
+`--show-dotfiles`
+: Show dot-prefixed files without showing other hidden files.
+
 `-d`, `--treat-dirs-as-files`
 : This flag, inherited from `ls`, changes how `eza` handles directory arguments.
 

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -89,6 +89,7 @@ impl Dir {
             inner: self.contents.iter(),
             dir: self,
             dotfiles: dots.shows_dotfiles(),
+            windows_hidden: dots.shows_windows_hidden(),
             dots: dots.dots(),
             git,
             git_ignoring,
@@ -121,6 +122,9 @@ pub struct Files<'dir, 'ig> {
 
     /// Whether to include dotfiles in the list.
     dotfiles: bool,
+
+    /// Whether Windows hidden-attribute entries should be visible.
+    windows_hidden: bool,
 
     /// Whether the `.` or `..` directories should be produced first, before
     /// any files have been listed.
@@ -184,7 +188,7 @@ impl<'dir> Files<'dir, '_> {
                 // Windows has its own concept of hidden files, when dotfiles are
                 // hidden Windows hidden files should also be filtered out
                 #[cfg(windows)]
-                if !self.dotfiles && file.attributes().map_or(false, |a| a.hidden) {
+                if !self.windows_hidden && file.attributes().map_or(false, |a| a.hidden) {
                     continue;
                 }
 
@@ -244,6 +248,9 @@ pub enum DotFilter {
     /// Show files and dotfiles, but hide `.` and `..`.
     Dotfiles,
 
+    /// Show dotfiles by name only, but keep platform hidden-attribute files hidden.
+    DotfilesByName,
+
     /// Just show files, hiding anything beginning with a dot.
     #[default]
     JustFiles,
@@ -255,8 +262,21 @@ impl DotFilter {
         match self {
             Self::JustFiles => false,
             Self::Dotfiles => true,
+            Self::DotfilesByName => true,
             Self::DotfilesAndDots => true,
         }
+    }
+
+    /// Whether this filter should reveal Windows hidden-attribute entries.
+    fn shows_windows_hidden(self) -> bool {
+        #[cfg(windows)]
+        match self {
+            Self::Dotfiles | Self::DotfilesAndDots => true,
+            Self::DotfilesByName | Self::JustFiles => false,
+        }
+
+        #[cfg(not(windows))]
+        false
     }
 
     /// Whether this filter should add dot directories to a listing.
@@ -264,7 +284,70 @@ impl DotFilter {
         match self {
             Self::JustFiles => DotsNext::Files,
             Self::Dotfiles => DotsNext::Files,
+            Self::DotfilesByName => DotsNext::Files,
             Self::DotfilesAndDots => DotsNext::Dot,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[cfg(windows)]
+    mod windows {
+        use super::*;
+        use std::os::windows::ffi::OsStrExt;
+        use std::path::Path;
+        use std::time::{SystemTime, UNIX_EPOCH};
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_ATTRIBUTE_HIDDEN, GetFileAttributesW, SetFileAttributesW,
+        };
+
+        fn unique_temp_dir() -> std::path::PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time went backwards")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("eza-show-dotfiles-{nanos}"));
+            fs::create_dir_all(&path).expect("failed to create temp dir");
+            path
+        }
+
+        fn set_hidden(path: &Path) {
+            let wide = path
+                .as_os_str()
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect::<Vec<_>>();
+            unsafe {
+                let attrs = GetFileAttributesW(wide.as_ptr());
+                assert_ne!(attrs, u32::MAX);
+                assert_ne!(SetFileAttributesW(wide.as_ptr(), attrs | FILE_ATTRIBUTE_HIDDEN), 0);
+            }
+        }
+
+        #[test]
+        fn show_dotfiles_does_not_show_windows_hidden_attributes() {
+            let path = unique_temp_dir();
+            fs::write(path.join(".dotfile"), "").unwrap();
+            fs::write(path.join("_underscore"), "").unwrap();
+            fs::write(path.join("hidden.txt"), "").unwrap();
+            set_hidden(&path.join("hidden.txt"));
+
+            let dir = Dir::read_dir(path.clone()).unwrap();
+
+            let names: Vec<_> = dir
+                .files(DotFilter::DotfilesByName, None, false, false, false)
+                .map(|file| file.name)
+                .collect();
+
+            assert!(names.contains(&".dotfile".to_string()));
+            assert!(names.contains(&"_underscore".to_string()));
+            assert!(!names.contains(&"hidden.txt".to_string()));
+
+            let _ = fs::remove_dir_all(path);
         }
     }
 }

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -291,64 +291,59 @@ impl DotFilter {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, windows))]
 mod tests {
     use super::*;
     use std::fs;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_HIDDEN, GetFileAttributesW, SetFileAttributesW,
+    };
 
-    #[cfg(windows)]
-    mod windows {
-        use super::*;
-        use std::os::windows::ffi::OsStrExt;
-        use std::path::Path;
-        use std::time::{SystemTime, UNIX_EPOCH};
-        use windows_sys::Win32::Storage::FileSystem::{
-            FILE_ATTRIBUTE_HIDDEN, GetFileAttributesW, SetFileAttributesW,
-        };
+    fn unique_temp_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("eza-show-dotfiles-{nanos}"));
+        fs::create_dir_all(&path).expect("failed to create temp dir");
+        path
+    }
 
-        fn unique_temp_dir() -> std::path::PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("time went backwards")
-                .as_nanos();
-            let path = std::env::temp_dir().join(format!("eza-show-dotfiles-{nanos}"));
-            fs::create_dir_all(&path).expect("failed to create temp dir");
-            path
+    fn set_hidden(path: &Path) {
+        let wide = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        unsafe {
+            let attrs = GetFileAttributesW(wide.as_ptr());
+            assert_ne!(attrs, u32::MAX);
+            assert_ne!(SetFileAttributesW(wide.as_ptr(), attrs | FILE_ATTRIBUTE_HIDDEN), 0);
         }
+    }
 
-        fn set_hidden(path: &Path) {
-            let wide = path
-                .as_os_str()
-                .encode_wide()
-                .chain(std::iter::once(0))
-                .collect::<Vec<_>>();
-            unsafe {
-                let attrs = GetFileAttributesW(wide.as_ptr());
-                assert_ne!(attrs, u32::MAX);
-                assert_ne!(SetFileAttributesW(wide.as_ptr(), attrs | FILE_ATTRIBUTE_HIDDEN), 0);
-            }
-        }
+    #[test]
+    fn show_dotfiles_does_not_show_windows_hidden_attributes() {
+        let path = unique_temp_dir();
+        fs::write(path.join(".dotfile"), "").unwrap();
+        fs::write(path.join("_underscore"), "").unwrap();
+        fs::write(path.join("hidden.txt"), "").unwrap();
+        set_hidden(&path.join("hidden.txt"));
 
-        #[test]
-        fn show_dotfiles_does_not_show_windows_hidden_attributes() {
-            let path = unique_temp_dir();
-            fs::write(path.join(".dotfile"), "").unwrap();
-            fs::write(path.join("_underscore"), "").unwrap();
-            fs::write(path.join("hidden.txt"), "").unwrap();
-            set_hidden(&path.join("hidden.txt"));
+        let dir = Dir::read_dir(path.clone()).unwrap();
 
-            let dir = Dir::read_dir(path.clone()).unwrap();
+        let names: Vec<_> = dir
+            .files(DotFilter::DotfilesByName, None, false, false, false)
+            .map(|file| file.name)
+            .collect();
 
-            let names: Vec<_> = dir
-                .files(DotFilter::DotfilesByName, None, false, false, false)
-                .map(|file| file.name)
-                .collect();
+        assert!(names.contains(&".dotfile".to_string()));
+        assert!(names.contains(&"_underscore".to_string()));
+        assert!(!names.contains(&"hidden.txt".to_string()));
 
-            assert!(names.contains(&".dotfile".to_string()));
-            assert!(names.contains(&"_underscore".to_string()));
-            assert!(!names.contains(&"hidden.txt".to_string()));
-
-            let _ = fs::remove_dir_all(path);
-        }
+        let _ = fs::remove_dir_all(path);
     }
 }

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -270,13 +270,14 @@ impl DotFilter {
     /// Whether this filter should reveal Windows hidden-attribute entries.
     fn shows_windows_hidden(self) -> bool {
         #[cfg(windows)]
-        match self {
-            Self::Dotfiles | Self::DotfilesAndDots => true,
-            Self::DotfilesByName | Self::JustFiles => false,
+        {
+            matches!(self, Self::Dotfiles | Self::DotfilesAndDots)
         }
 
         #[cfg(not(windows))]
-        false
+        {
+            false
+        }
     }
 
     /// Whether this filter should add dot directories to a listing.

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -269,15 +269,7 @@ impl DotFilter {
 
     /// Whether this filter should reveal Windows hidden-attribute entries.
     fn shows_windows_hidden(self) -> bool {
-        #[cfg(windows)]
-        {
-            matches!(self, Self::Dotfiles | Self::DotfilesAndDots)
-        }
-
-        #[cfg(not(windows))]
-        {
-            false
-        }
+        cfg!(windows) && matches!(self, Self::Dotfiles | Self::DotfilesAndDots)
     }
 
     /// Whether this filter should add dot directories to a listing.

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -99,14 +99,17 @@ impl DotFilter {
     pub fn deduce(matches: &ArgMatches, strict: bool) -> Result<Self, OptionsError> {
         let all_count = matches.get_count("all");
         let has_almost_all = matches.get_flag("almost-all");
+        let show_dotfiles = matches.get_flag("show-dotfiles");
 
-        match (all_count, has_almost_all) {
-            (0, false) => Ok(Self::JustFiles),
+        if has_almost_all {
+            return Ok(Self::Dotfiles);
+        }
 
-            // either a single --all or at least one --almost-all is given
-            (1, _) | (0, true) => Ok(Self::Dotfiles),
-            // more than one --all
-            (c, _) => {
+        match all_count {
+            0 if show_dotfiles => Ok(Self::DotfilesByName),
+            0 => Ok(Self::JustFiles),
+            1 => Ok(Self::Dotfiles),
+            c => {
                 if matches.get_flag("tree") {
                     Err(OptionsError::TreeAllAll)
                 } else if strict && c > 2 {
@@ -246,6 +249,22 @@ mod tests {
     fn deduce_dot_filter_almost_all() {
         assert_eq!(
             DotFilter::deduce(&mock_cli(vec!["--almost-all"]), false),
+            Ok(DotFilter::Dotfiles)
+        );
+    }
+
+    #[test]
+    fn deduce_dot_filter_show_dotfiles() {
+        assert_eq!(
+            DotFilter::deduce(&mock_cli(vec!["--show-dotfiles"]), false),
+            Ok(DotFilter::DotfilesByName)
+        );
+    }
+
+    #[test]
+    fn deduce_dot_filter_show_dotfiles_and_all() {
+        assert_eq!(
+            DotFilter::deduce(&mock_cli(vec!["--show-dotfiles", "--all"]), false),
             Ok(DotFilter::Dotfiles)
         );
     }

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -94,6 +94,7 @@ pub fn get_command() -> clap::Command {
         .next_help_heading("FILTERING OPTIONS")
         .arg(arg!(-a --all... "show hidden files. Use this twice to also show the '.' and '..' directories"))
         .arg(arg!(-A --"almost-all" "equivalent to --all; included for compatibility with `ls -A`"))
+        .arg(arg!(--"show-dotfiles" "show dot-prefixed files without showing other hidden files"))
         .arg(arg!(-d --"treat-dirs-as-files" "treat directories as files; don't list their contents")
             .alias("list-dirs") // TODO: compat alias to remove (above flag published in v0.23.4 / 2025-10-03)
             .conflicts_with_all(["recurse", "tree"]))

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -32,6 +32,7 @@ DISPLAY OPTIONS:
 FILTERING OPTIONS:
   -a, --all...               show hidden files. Use this twice to also show the '.' and '..' directories
   -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
+      --show-dotfiles        show dot-prefixed files without showing other hidden files
   -d, --treat-dirs-as-files  treat directories as files; don't list their contents
   -D, --only-dirs            list only directories
   -f, --only-files           list only files


### PR DESCRIPTION
On Unix-like systems, "hidden" usually means a name starts with dot (`.`). On Windows, there is also a separate filesystem `hidden` attribute. Because of that, `-a` is often a reasonable way to show dotfiles on Unix-like systems, but can be much noisier on Windows.

Examples:

Unix-like:
```console
eza -l
-rw-r--r-- file.txt

eza -la
lrwxrwxrwx .aws -> /some/shared/path
-rw-r--r-- .bashrc
-rw-r--r-- file.txt
```

Windows:
```console
eza -l
d-r-- Documents
d---- source

eza -la
d---- .dotnet
d---- .nuget
l--hs 'Application Data' -> C:\Users\name\AppData\Roaming
l--hs Cookies -> C:\Users\name\AppData\Local\Microsoft\Windows\INetCookies
-a-h- NTUSER.DAT
---h- XORXOR659040683.doc
---h- XORXOR779122472.db
---h- ZZZZZ2148549623.pdf
```

This PR adds `--show-dotfiles` as a narrower option:
- shows dot-prefixed entries on all platforms
- on Windows, also shows `_`-prefixed entries, matching eza's existing hidden-by-name behavior
- does not show Windows hidden-attribute entries
- does not change `-a` or `-aa`

Unix-like:
```console
eza -l --show-dotfiles
lrwxrwxrwx .aws -> /some/shared/path
-rw-r--r-- .bashrc
-rw-r--r-- file.txt
```

Windows:
```console
eza -l --show-dotfiles
d---- .dotnet
d---- .nuget
d-r-- Documents
d---- source
```


This helps with a common Windows case where -a is too broad because it also reveals hidden-attribute files and Windows hidden links/aliases.

Some entries in a Windows home directory are also hidden links/aliases rather than regular files or directories. Examples include entries such as `Local Settings` and `SendTo`. Links do not have to be hidden in general, but many of these Windows profile links are.

Those entries are intentionally out of scope for this PR. This change focuses only on showing dotfiles without also enabling the broader Windows hidden-attribute view. A sister PR will follow to add a way to show those hidden Windows links/aliases as well.

Fixes #1720.