### PR TITLE
feat(time): accept 'r', 'm' as aliases for --time modified

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -239,7 +239,7 @@ These options are available when running with `--long` (`-l`):
 `-t`, `--time=WORD`
 : Which timestamp field to list.
 
-: Valid timestamp fields are ‘`modified`’, ‘`changed`’, ‘`accessed`’, and ‘`created`’.
+: Valid timestamp fields are ‘`modified`’ (also ‘`mod`’, ‘`m`’, or ‘`r`’), ‘`changed`’ (also ‘`ch`’), ‘`accessed`’ (also ‘`acc`’), and ‘`created`’ (also ‘`cr`’).  The ‘`r`’ alias means the same as ‘`modified`’ and is provided so that `eza -ltr` and similar `ls`-style invocations don't error out.
 
 `--time-style=STYLE`
 : How to format timestamps.

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -19,7 +19,7 @@ const SORT_FIELDS_HELP: &str = "[default: name] [possible values:
   size, inode, type, none]";
 
 const TIME_FIELDS_HELP: &str = "[possible values:
-  mod|modified, acc|accessed, ch|changed, cr|created]";
+  m|mod|r|modified, acc|accessed, ch|changed, cr|created]";
 
 const FORMAT_STYLE_FIELDS_HELP: &str = "[possible values:
   default, iso, long-iso, full-iso, relative, \"+<CUSTOM_FORMAT>\"]";
@@ -266,7 +266,7 @@ impl ValueEnum for TimeArgs {
 
     fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
         Some(match self {
-            Self::Modified => PossibleValue::new("modified").alias("mod"),
+            Self::Modified => PossibleValue::new("modified").aliases(["mod", "m", "r"]),
             Self::Changed => PossibleValue::new("changed").alias("ch"),
             Self::Accessed => PossibleValue::new("accessed").alias("acc"),
             Self::Created => PossibleValue::new("created").alias("cr"),

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -584,6 +584,39 @@ mod tests {
     }
 
     #[test]
+    fn deduce_time_types_modified_alias_r() {
+        assert_eq!(
+            TimeTypes::deduce(&mock_cli(vec!["--time", "r"])),
+            Ok(TimeTypes {
+                modified: true,
+                ..TimeTypes::default()
+            })
+        );
+    }
+
+    #[test]
+    fn deduce_time_types_modified_alias_m() {
+        assert_eq!(
+            TimeTypes::deduce(&mock_cli(vec!["--time", "m"])),
+            Ok(TimeTypes {
+                modified: true,
+                ..TimeTypes::default()
+            })
+        );
+    }
+
+    #[test]
+    fn deduce_time_types_modified_alias_mod() {
+        assert_eq!(
+            TimeTypes::deduce(&mock_cli(vec!["--time", "mod"])),
+            Ok(TimeTypes {
+                modified: true,
+                ..TimeTypes::default()
+            })
+        );
+    }
+
+    #[test]
     fn deduce_time_types_accessed_word() {
         assert_eq!(
             TimeTypes::deduce(&mock_cli(vec!["--time", "accessed"])),

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -62,7 +62,7 @@ LONG VIEW OPTIONS:
       --smart-group          only show group if it has a different name from owner
   -n, --numeric              show user and group as their numeric IDs
   -t, --time <FIELD>         which timestamp field to show [possible values:
-                               mod|modified, acc|accessed, ch|changed, cr|created]
+                               m|mod|r|modified, acc|accessed, ch|changed, cr|created]
   -m, --modified             show the modified timestamp field (replace default field, combinable)
   -u, --accessed             show the accessed timestamp field (replace default field, combinable)
       --changed              show the changed timestamp field (replace default field, combinable)


### PR DESCRIPTION
Adds `r`, `m`, and `mod` as aliases for `modified` on the `--time`/`-t` value, which closes #1573 by letting `eza -ltr` (and similar `ls`-style muscle-memory invocations) parse without erroring on the `r` value.

The issue has been sitting open for a while with a steady trickle of people running into the same papercut: an alias like `alias ls=eza` plus `ls -ltr` blows up with `Option --time (-t) has no "r" setting`. The fix here is intentionally narrow. It does not try to make `-ltr` magically reverse the sort, and it does not pull in any of the other `ls` flag semantics. It just teaches `--time` to accept `r` (which the issue author asked for explicitly) as another spelling of `modified`. If someone wants the actual `ls -ltr` ordering they can still combine it with `--reverse` or `--sort=oldest`, but at least the parser stops getting in the way.

I also added `m` and `mod` since the existing pattern in `TimeArgs::to_possible_value` already gives `Changed`, `Accessed`, and `Created` short two-letter aliases (`ch`, `acc`, `cr`), and adding only `r` to `Modified` would feel asymmetric. `m` lines up with the existing `-m`/`--modified` short flag, so it should not surprise anyone.

Tested locally:

```
$ eza -ltr /tmp/ezatest
.rw-rw-r-- 0 kali  6 May 15:20 a
.rw-rw-r-- 0 kali  6 May 15:20 b
.rw-rw-r-- 0 kali  6 May 15:20 c

$ eza --time m /tmp/ezatest
a  b  c

$ eza --time q /tmp/ezatest
error: invalid value 'q' for '--time <FIELD>'
  [possible values: modified, changed, accessed, created]
```

So valid aliases work, the error path for actually-invalid values still fires with the canonical choice list, and the existing `mod` alias keeps working. Three new tests in `src/options/view.rs` cover `r`, `m`, and `mod`. `cargo test` passes (335/335 unit + 2 CLI + 3 doc) and `cargo clippy -- -D warnings` is clean.

The man page got a one-line update to spell out the aliases. Completion files were left alone since they only list the canonical names today (none of `mod`, `ch`, `acc`, `cr` are in there either).