### PR TITLE
feat: add aarch64-unknown-linux-musl release build

### DIFF
--- a/justfile
+++ b/justfile
@@ -263,6 +263,9 @@ alias c := cross
     just binary eza aarch64-unknown-linux-gnu
     just binary_no_libgit eza aarch64-unknown-linux-gnu
     # BUG: just binary_static eza aarch64-unknown-linux-gnu
+    just binary eza aarch64-unknown-linux-musl
+    just binary_no_libgit eza aarch64-unknown-linux-musl
+    # just binary_static eza aarch64-unknown-linux-musl
 
     ### arm
     just binary eza arm-unknown-linux-gnueabihf


### PR DESCRIPTION
## What

Adds `aarch64-unknown-linux-musl` to the `cross` release recipe in `justfile`, so each tagged release ships a static arm64 binary alongside the existing `x86_64-unknown-linux-musl` archive.

The two new lines mirror the existing `aarch64-unknown-linux-gnu` entry directly above: one `just binary` (default features, libgit2) and one `just binary_no_libgit` (for environments where dynamic libgit2 isn't desired). Same pattern, just for the musl triple.

```
### aarch
just binary eza aarch64-unknown-linux-gnu
just binary_no_libgit eza aarch64-unknown-linux-gnu
# BUG: just binary_static eza aarch64-unknown-linux-gnu
just binary eza aarch64-unknown-linux-musl
just binary_no_libgit eza aarch64-unknown-linux-musl
# just binary_static eza aarch64-unknown-linux-musl
```

## Why

Alpine arm64 and OpenWRT arm64 users currently have to build from source because the released `aarch64-unknown-linux-gnu` archive is dynamically linked against glibc, which Alpine/OpenWRT don't ship. A musl arm64 release rounds out the matrix (the x86_64 musl build has been shipped for a long time).

Requested in #1776.

## Verification

Built locally with `cross` 0.2.5 + Docker. Both invocations succeed:

```
cross build --release --target aarch64-unknown-linux-musl
cross build --no-default-features --release --target aarch64-unknown-linux-musl
```

Output ELF is `ARM aarch64, statically linked, stripped` (per `file(1)`), ~2.4 MiB.

I have not run the full `just cross` end-to-end on a tagged commit because that recipe also exercises Windows + arm-gnueabihf and depends on `convco` versioning, but the two binary recipes added here build cleanly in the same `cross`/Docker environment the release pipeline uses.

Closes #1776